### PR TITLE
New Clay Render system

### DIFF
--- a/io/yaf_export.py
+++ b/io/yaf_export.py
@@ -194,17 +194,17 @@ class YafaRayRenderEngine(bpy.types.RenderEngine):
                 self.handleBlendMat(mat1)
             elif mat1 not in self.materials:
                 self.materials.add(mat1)
-                self.yaf_material.writeMaterial(mat1)
+                self.yaf_material.writeMaterial(mat1, self.scene)
 
             if mat2.mat_type == 'blend':
                 self.handleBlendMat(mat2)
             elif mat2 not in self.materials:
                 self.materials.add(mat2)
-                self.yaf_material.writeMaterial(mat2)
+                self.yaf_material.writeMaterial(mat2, self.scene)
 
             if mat not in self.materials:
                 self.materials.add(mat)
-                self.yaf_material.writeMaterial(mat)
+                self.yaf_material.writeMaterial(mat, self.scene)
 
     def exportMaterials(self):
         self.yi.printInfo("Exporter: Processing Materials...")
@@ -213,19 +213,23 @@ class YafaRayRenderEngine(bpy.types.RenderEngine):
         # create a default shiny diffuse material -> it will be assigned, if object has no material(s)
         self.yi.paramsClearAll()
         self.yi.paramsSetString("type", "shinydiffusemat")
-        self.yi.paramsSetColor("color", 0.8, 0.8, 0.8)
+        if self.scene.gs_clay_render:    
+            cCol = self.scene.gs_clay_col
+        else:
+            cCol = (0.8, 0.8, 0.8)
+        self.yi.paramsSetColor("color", cCol[0], cCol[1], cCol[2])
         self.yi.printInfo("Exporter: Creating Material \"defaultMat\"")
         ymat = self.yi.createMaterial("defaultMat")
         self.materialMap["default"] = ymat
 
-        # create a shiny diffuse material for "Clay Render" option in general settings
-        self.yi.paramsClearAll()
-        self.yi.paramsSetString("type", "shinydiffusemat")
-        cCol = self.scene.gs_clay_col
-        self.yi.paramsSetColor("color", cCol[0], cCol[1], cCol[2])
-        self.yi.printInfo("Exporter: Creating Material \"clayMat\"")
-        cmat = self.yi.createMaterial("clayMat")
-        self.materialMap["clay"] = cmat
+        # Obsolete: create a shiny diffuse material for "Clay Render" option in general settings
+        #self.yi.paramsClearAll()
+        #self.yi.paramsSetString("type", "shinydiffusemat")
+        #cCol = self.scene.gs_clay_col
+        #self.yi.paramsSetColor("color", cCol[0], cCol[1], cCol[2])
+        #self.yi.printInfo("Exporter: Creating Material \"clayMat\"")
+        #cmat = self.yi.createMaterial("clayMat")
+        #self.materialMap["clay"] = cmat
 
         for obj in self.scene.objects:
             for mat_slot in obj.material_slots:
@@ -240,7 +244,7 @@ class YafaRayRenderEngine(bpy.types.RenderEngine):
                 self.handleBlendMat(material)
             else:
                 self.materials.add(material)
-                self.yaf_material.writeMaterial(material, self.is_preview)
+                self.yaf_material.writeMaterial(material, self.scene, self.is_preview)
 
     def decideOutputFileName(self, output_path, filetype):
 

--- a/io/yaf_material.py
+++ b/io/yaf_material.py
@@ -205,7 +205,7 @@ class yafMaterial:
             nf = mtex.normal_factor * 2
             yi.paramsSetFloat("bump_strength", nf)
 
-    def writeGlassShader(self, mat, rough):
+    def writeGlassShader(self, mat, scene, rough):
 
         # mat : is an instance of material
         yi = self.yi
@@ -218,10 +218,15 @@ class yafMaterial:
             yi.paramsSetString("type", "glass")
 
         yi.paramsSetFloat("IOR", mat.IOR_refraction)  # added IOR for refraction
-        filt_col = mat.filter_color
+        if scene.gs_clay_render and not mat.clay_exclude:
+            filt_col = (1.0, 1.0, 1.0)
+            abs_col = (1.0, 1.0, 1.0)
+        else:
+            filt_col = mat.filter_color
+            abs_col = mat.absorption
         mir_col = mat.glass_mir_col
         tfilt = mat.glass_transmit
-        abs_col = mat.absorption
+        
 
         yi.paramsSetColor("filter_color", filt_col[0], filt_col[1], filt_col[2])
         yi.paramsSetColor("mirror_color", mir_col[0], mir_col[1], mir_col[2])
@@ -263,7 +268,7 @@ class yafMaterial:
 
         return yi.createMaterial(self.namehash(mat))
 
-    def writeGlossyShader(self, mat, coated):  # mat : instance of material class
+    def writeGlossyShader(self, mat, scene, coated):  # mat : instance of material class
         yi = self.yi
         yi.paramsClearAll()
 
@@ -337,7 +342,8 @@ class yafMaterial:
 
         return yi.createMaterial(self.namehash(mat))
 
-    def writeShinyDiffuseShader(self, mat):
+
+    def writeShinyDiffuseShader(self, mat, scene):
         yi = self.yi
         yi.paramsClearAll()
 
@@ -350,6 +356,14 @@ class yafMaterial:
         bTransl = mat.translucency
         bTransmit = mat.transmit_filter
         bEmit = mat.emit
+
+        if scene.gs_clay_render and not mat.clay_exclude:
+            bCol = scene.gs_clay_col
+            bSpecr = 0.0
+            bEmit = 0.0
+            if not scene.gs_clay_render_keep_transparency:
+                bTransp = 0.0
+                bTransl = 0.0
 
         if self.preview:
             if mat.name.startswith("checker"):
@@ -371,35 +385,41 @@ class yafMaterial:
             used = False
             mappername = "map%x" % i
 
-            lname = "diff_layer%x" % i
-            if self.writeTexLayer(lname, mappername, diffRoot, mtex, mtex.use_map_color_diffuse, bCol, mtex.diffuse_color_factor):
-                used = True
-                diffRoot = lname
+            if mat.clay_exclude or not scene.gs_clay_render:
+                lname = "diff_layer%x" % i
+                if self.writeTexLayer(lname, mappername, diffRoot, mtex, mtex.use_map_color_diffuse, bCol, mtex.diffuse_color_factor):
+                    used = True
+                    diffRoot = lname
 
-            lname = "mircol_layer%x" % i
-            if self.writeTexLayer(lname, mappername, mcolRoot, mtex, mtex.use_map_mirror, mirCol, mtex.mirror_factor):
-                used = True
-                mcolRoot = lname
+            if mat.clay_exclude or not scene.gs_clay_render:
+                lname = "mircol_layer%x" % i
+                if self.writeTexLayer(lname, mappername, mcolRoot, mtex, mtex.use_map_mirror, mirCol, mtex.mirror_factor):
+                    used = True
+                    mcolRoot = lname
 
-            lname = "transp_layer%x" % i
-            if self.writeTexLayer(lname, mappername, transpRoot, mtex, mtex.use_map_alpha, [bTransp], mtex.alpha_factor):
-                used = True
-                transpRoot = lname
+            if mat.clay_exclude or scene.gs_clay_render_keep_transparency or not scene.gs_clay_render:
+                lname = "transp_layer%x" % i
+                if self.writeTexLayer(lname, mappername, transpRoot, mtex, mtex.use_map_alpha, [bTransp], mtex.alpha_factor):
+                    used = True
+                    transpRoot = lname
 
-            lname = "translu_layer%x" % i
-            if self.writeTexLayer(lname, mappername, translRoot, mtex, mtex.use_map_translucency, [bTransl], mtex.translucency_factor):
-                used = True
-                translRoot = lname
+            if mat.clay_exclude or scene.gs_clay_render_keep_transparency or not scene.gs_clay_render:
+                lname = "translu_layer%x" % i
+                if self.writeTexLayer(lname, mappername, translRoot, mtex, mtex.use_map_translucency, [bTransl], mtex.translucency_factor):
+                    used = True
+                    translRoot = lname
 
-            lname = "mirr_layer%x" % i
-            if self.writeTexLayer(lname, mappername, mirrorRoot, mtex, mtex.use_map_raymir, [bSpecr], mtex.raymir_factor):
-                used = True
-                mirrorRoot = lname
+            if mat.clay_exclude or not scene.gs_clay_render:
+                lname = "mirr_layer%x" % i
+                if self.writeTexLayer(lname, mappername, mirrorRoot, mtex, mtex.use_map_raymir, [bSpecr], mtex.raymir_factor):
+                    used = True
+                    mirrorRoot = lname
 
-            lname = "bump_layer%x" % i
-            if self.writeTexLayer(lname, mappername, bumpRoot, mtex, mtex.use_map_normal, [0], mtex.normal_factor):
-                used = True
-                bumpRoot = lname
+            if mat.clay_exclude or scene.gs_clay_render_keep_normals or not scene.gs_clay_render:
+                lname = "bump_layer%x" % i
+                if self.writeTexLayer(lname, mappername, bumpRoot, mtex, mtex.use_map_normal, [0], mtex.normal_factor):
+                    used = True
+                    bumpRoot = lname
 
             if used:
                 self.writeMappingNode(mappername, mtex.texture.name, mtex)
@@ -431,13 +451,17 @@ class yafMaterial:
         yi.paramsSetBool("fresnel_effect", mat.fresnel_effect)
         yi.paramsSetFloat("IOR", mat.IOR_reflection)  # added IOR for reflection
 
-        if mat.brdf_type == "oren-nayar":  # oren-nayar fix for shinydiffuse
+        if scene.gs_clay_render and not mat.clay_exclude:
+             if scene.gs_clay_oren_nayar:
+                 yi.paramsSetString("diffuse_brdf", "oren_nayar")
+                 yi.paramsSetFloat("sigma", scene.gs_clay_sigma)
+        elif mat.brdf_type == "oren-nayar":  # oren-nayar fix for shinydiffuse
             yi.paramsSetString("diffuse_brdf", "oren_nayar")
             yi.paramsSetFloat("sigma", mat.sigma)
 
         return yi.createMaterial(self.namehash(mat))
 
-    def writeBlendShader(self, mat):
+    def writeBlendShader(self, mat, scene):
         yi = self.yi
         yi.paramsClearAll()
 
@@ -477,37 +501,41 @@ class yafMaterial:
 
         return yi.createMaterial(self.namehash(mat))
 
-    def writeMatteShader(self, mat):
+    def writeMatteShader(self, mat, scene):
         yi = self.yi
         yi.paramsClearAll()
         yi.paramsSetString("type", "shadow_mat")
         return yi.createMaterial(self.namehash(mat))
 
-    def writeNullMat(self, mat):
+    def writeNullMat(self, mat, scene):
         yi = self.yi
         yi.paramsClearAll()
         yi.paramsSetString("type", "null")
         return yi.createMaterial(self.namehash(mat))
 
-    def writeMaterial(self, mat, preview=False):
+    def writeMaterial(self, mat, scene, preview=False):
         self.preview = preview
         self.yi.printInfo("Exporter: Creating Material: \"" + self.namehash(mat) + "\"")
         ymat = None
         if mat.name == "y_null":
-            ymat = self.writeNullMat(mat)
+            ymat = self.writeNullMat(mat, scene)
+        elif scene.gs_clay_render and not mat.clay_exclude and not (scene.gs_clay_render_keep_transparency and mat.mat_type == "glass"):
+            ymat = self.writeShinyDiffuseShader(mat, scene)
         elif mat.mat_type == "glass":
-            ymat = self.writeGlassShader(mat, False)
+            ymat = self.writeGlassShader(mat, scene, False)
         elif mat.mat_type == "rough_glass":
-            ymat = self.writeGlassShader(mat, True)
+            ymat = self.writeGlassShader(mat, scene, True)
         elif mat.mat_type == "glossy":
-            ymat = self.writeGlossyShader(mat, False)
+            ymat = self.writeGlossyShader(mat, scene, False)
         elif mat.mat_type == "coated_glossy":
-            ymat = self.writeGlossyShader(mat, True)
+            ymat = self.writeGlossyShader(mat, scene, True)
         elif mat.mat_type == "shinydiffusemat":
-            ymat = self.writeShinyDiffuseShader(mat)
+            ymat = self.writeShinyDiffuseShader(mat, scene)
         elif mat.mat_type == "blend":
-            ymat = self.writeBlendShader(mat)
+            ymat = self.writeBlendShader(mat, scene)   #FIXME: in the new Clay render two limitations:
+                #We cannot yet keep transparency in Blend objects. If that's needed to test a scene, better to exclude that particular material from the Clay
+                #We cannot exclude just the blended material from the Clay render, the individual materials that are used to make the blend also have to be excluded
         else:
-            ymat = self.writeNullMat(mat)
+            ymat = self.writeNullMat(mat, scene)
 
         self.materialMap[mat] = ymat

--- a/io/yaf_material.py
+++ b/io/yaf_material.py
@@ -352,6 +352,7 @@ class yafMaterial:
         bCol = mat.diffuse_color
         mirCol = mat.mirror_color
         bSpecr = mat.specular_reflect
+        bDiffRefl = mat.diffuse_reflect
         bTransp = mat.transparency
         bTransl = mat.translucency
         bTransmit = mat.transmit_filter
@@ -361,6 +362,7 @@ class yafMaterial:
             bCol = scene.gs_clay_col
             bSpecr = 0.0
             bEmit = 0.0
+            bDiffRefl = 1.0
             if not scene.gs_clay_render_keep_transparency:
                 bTransp = 0.0
                 bTransl = 0.0
@@ -442,7 +444,7 @@ class yafMaterial:
         yi.paramsSetColor("color", bCol[0], bCol[1], bCol[2])
         yi.paramsSetFloat("transparency", bTransp)
         yi.paramsSetFloat("translucency", bTransl)
-        yi.paramsSetFloat("diffuse_reflect", mat.diffuse_reflect)
+        yi.paramsSetFloat("diffuse_reflect", bDiffRefl)
         yi.paramsSetFloat("emit", bEmit)
         yi.paramsSetFloat("transmit_filter", bTransmit)
 

--- a/io/yaf_object.py
+++ b/io/yaf_object.py
@@ -467,9 +467,9 @@ class yafObject(object):
 
         ymaterial = self.materialMap["default"]
 
-        if self.scene.gs_clay_render:
-            ymaterial = self.materialMap["clay"]
-        elif len(meshMats) and meshMats[matIndex]:
+        #if self.scene.gs_clay_render:
+        #    ymaterial = self.materialMap["clay"]
+        if len(meshMats) and meshMats[matIndex]:
             mat = meshMats[matIndex]
             if mat in self.materialMap:
                 ymaterial = self.materialMap[mat]

--- a/prop/yaf_material.py
+++ b/prop/yaf_material.py
@@ -236,6 +236,11 @@ def register():
         description="Let light straight through for shadow calculation. Not to be used with dispersion",
         default=False)
 
+    Material.clay_exclude = BoolProperty(
+        name="Exclude from Clay render",
+        description="Exclude from Clay render mode: this material will be rendered normally even in Clay render mode",
+        default=False)
+
     Material.blend_value = FloatProperty(
         name="Blend value",
         description="The mixing balance: 0 -> only material 1, 1.0 -> only material 2",
@@ -299,6 +304,7 @@ def unregister():
     del Material.dispersion_power
     del Material.refr_roughness
     del Material.fake_shadows
+    del Material.clay_exclude
     del Material.blend_value
     del Material.sigma
     del Material.rough

--- a/prop/yaf_scene.py
+++ b/prop/yaf_scene.py
@@ -98,13 +98,37 @@ def register():
         description="Override all materials with a white diffuse material",
         default=False)
 
+    Scene.gs_clay_render_keep_transparency = BoolProperty(
+        name="Clay: keep transparency",
+        description="Keep transparency during clay render",
+        default=False)
+
+    Scene.gs_clay_render_keep_normals = BoolProperty(
+        name="Clay: keep normal/bump maps",
+        description="Keep normal and bump maps during clay render",
+        default=False)
+
+    Scene.gs_clay_oren_nayar = BoolProperty(
+        name="Clay: use Oren-Nayar shader",
+        description="Use Oren-Nayar shader for a more realistic diffuse clay render",
+        default=True)
+
+    Scene.gs_clay_sigma = FloatProperty(
+        name="Sigma for Clay Oren Nayar",
+        description="Roughness of the clay surfaces when rendering with Clay-Oren Nayar",
+        min=0.0, max=1.0,
+        step=1, precision=5,
+        soft_min=0.0, soft_max=1.0,
+        default=0.10000)
+
+
     # added clay color property
     Scene.gs_clay_col = FloatVectorProperty(
         name="Clay color",
         description="Color of clay render material",
         subtype='COLOR',
         min=0.0, max=1.0,
-        default=(0.8, 0.8, 0.8))
+        default=(0.5, 0.5, 0.5))
 
     Scene.gs_mask_render = BoolProperty(
         name="Render mask",
@@ -408,6 +432,10 @@ def unregister():
     Scene.gs_tile_order
     Scene.gs_auto_threads
     Scene.gs_clay_render
+    Scene.gs_clay_render_keep_transparency
+    Scene.gs_clay_render_keep_normals
+    Scene.gs_clay_oren_nayar
+    Scene.gs_clay_sigma
     Scene.gs_clay_col
     Scene.gs_mask_render
     Scene.gs_draw_params

--- a/prop/yaf_scene.py
+++ b/prop/yaf_scene.py
@@ -99,27 +99,27 @@ def register():
         default=False)
 
     Scene.gs_clay_render_keep_transparency = BoolProperty(
-        name="Clay: keep transparency",
+        name="Keep transparency",
         description="Keep transparency during clay render",
         default=False)
 
     Scene.gs_clay_render_keep_normals = BoolProperty(
-        name="Clay: keep normal/bump maps",
+        name="Keep normal/bump maps",
         description="Keep normal and bump maps during clay render",
         default=False)
 
     Scene.gs_clay_oren_nayar = BoolProperty(
-        name="Clay: use Oren-Nayar shader",
+        name="Oren-Nayar",
         description="Use Oren-Nayar shader for a more realistic diffuse clay render",
         default=True)
 
     Scene.gs_clay_sigma = FloatProperty(
-        name="Sigma for Clay Oren Nayar",
+        name="Sigma",
         description="Roughness of the clay surfaces when rendering with Clay-Oren Nayar",
         min=0.0, max=1.0,
         step=1, precision=5,
         soft_min=0.0, soft_max=1.0,
-        default=0.10000)
+        default=0.30000)
 
 
     # added clay color property

--- a/ui/properties_yaf_general_settings.py
+++ b/ui/properties_yaf_general_settings.py
@@ -82,6 +82,11 @@ class YAF_PT_general_settings(RenderButtonsPanel, Panel):
         col = split.column()
         if scene.gs_clay_render:
             col.prop(scene, "gs_clay_col", text="")
+            col.prop(scene, "gs_clay_oren_nayar")
+            if scene.gs_clay_oren_nayar:
+                col.prop(scene, "gs_clay_sigma")
+            col.prop(scene, "gs_clay_render_keep_transparency")
+            col.prop(scene, "gs_clay_render_keep_normals")
         col.prop(scene, "gs_auto_threads", toggle=True)
         col.prop(scene, "gs_show_sam_pix", toggle=True)
         col.prop(render, "use_instances", text="Use instances", toggle=True)

--- a/ui/properties_yaf_general_settings.py
+++ b/ui/properties_yaf_general_settings.py
@@ -31,7 +31,7 @@ class YAFARAY_MT_presets_render(Menu):
     preset_subdir = "render"
     preset_operator = "script.execute_preset"
     draw = yafaray_presets.Yafaray_Menu.draw_preset
-
+    
 
 class YAF_PT_general_settings(RenderButtonsPanel, Panel):
     bl_label = "General Settings"
@@ -73,20 +73,12 @@ class YAF_PT_general_settings(RenderButtonsPanel, Panel):
 
         split = layout.split()
         col = split.column()
-        col.prop(scene, "gs_clay_render", toggle=True)
         col.prop(scene, "gs_z_channel", toggle=True)
         col.prop(scene, "gs_transp_shad", toggle=True)
         col.prop(scene, "gs_draw_params", toggle=True)
         col.prop(scene, "gs_clamp_rgb", toggle=True)
 
         col = split.column()
-        if scene.gs_clay_render:
-            col.prop(scene, "gs_clay_col", text="")
-            col.prop(scene, "gs_clay_oren_nayar")
-            if scene.gs_clay_oren_nayar:
-                col.prop(scene, "gs_clay_sigma")
-            col.prop(scene, "gs_clay_render_keep_transparency")
-            col.prop(scene, "gs_clay_render_keep_normals")
         col.prop(scene, "gs_auto_threads", toggle=True)
         col.prop(scene, "gs_show_sam_pix", toggle=True)
         col.prop(render, "use_instances", text="Use instances", toggle=True)
@@ -103,6 +95,35 @@ class YAF_PT_general_settings(RenderButtonsPanel, Panel):
         col = layout.column()
         col.enabled = scene.gs_draw_params
         col.prop(scene, "gs_custom_string")
+
+
+class YAFARAY_MT_clay_render(RenderButtonsPanel, Panel):
+    bl_label = "Clay Render Settings"
+
+    def draw(self, context):
+        layout = self.layout
+        scene = context.scene
+        render = scene.render
+
+        row = layout.row(align=True)
+        split = layout.split(percentage=0.5)
+        col = split.column()
+        col.prop(scene, "gs_clay_render", toggle=True)
+        if scene.gs_clay_render:
+            col = split.column()
+            col.prop(scene, "gs_clay_col", text="")
+            layout.separator()
+            split = layout.split()
+            col = split.column()
+            col.prop(scene, "gs_clay_oren_nayar")
+            if scene.gs_clay_oren_nayar:
+                col = split.column()
+                col.prop(scene, "gs_clay_sigma")            
+            col = layout.column()
+            col.prop(scene, "gs_clay_render_keep_transparency")
+            #col = split.column()
+            col.prop(scene, "gs_clay_render_keep_normals")
+
 
 
 if __name__ == "__main__":  # only for live edit.

--- a/ui/properties_yaf_material.py
+++ b/ui/properties_yaf_material.py
@@ -95,6 +95,7 @@ class YAF_PT_context_material(MaterialButtonsPanel, Panel):
         if yaf_mat:
             layout.separator()
             layout.prop(yaf_mat, "mat_type")
+            layout.row().prop(yaf_mat, "clay_exclude")
 
 
 class YAF_MATERIAL_PT_preview(MaterialButtonsPanel, Panel):


### PR DESCRIPTION
Major changes to the Clay Render system to make it more flexible and powerful, as requested in several feature requests in the bug tracker:
* Clay pass but keeping transparency/translucency  http://www.yafaray.org/node/541
* clay render with original relief maps  http://www.yafaray.org/node/600
* Clay render with Oren Nayar shading  http://www.yafaray.org/node/602
* Material off clay render  http://www.yafaray.org/node/599
* Clay render default color  http://www.yafaray.org/node/618

The old system of a "temporary" ClayMat material has been overriden and no longer works. The new system consists in altering the properties of the materials in the export process, so we can keep some of their properties and do a more fine grained control.
* Default Clay color is now 0.5,0.5,0.5 (Midle-Grey), it can be changed (as before)
* Default Clay shader is diffuse shader Oren-Nayar sigma=0.5. The Oren Nayar shader can be disabled to use the standard diffuse shader.
* Option to keep transpareny in glass/transparent objects during Clay Render (also keeps transparent textures). It does not work yet in Blend materials.
* Option to keep bump/normal maps during Clay Render.
* Per-material option to exclude a certain material from the Clay Render. If a material is excluded, it shows normally during the Clay Render. For now this works only partially in Blend materials: if you want to exclude a Blend material you can, but you also need to exclude all the individual materials that make the blended material.

I hope you find this useful.

 Changes to be committed:
	modified:   io/yaf_export.py
	modified:   io/yaf_material.py
	modified:   io/yaf_object.py
	modified:   prop/yaf_material.py
	modified:   prop/yaf_scene.py
	modified:   ui/properties_yaf_general_settings.py
	modified:   ui/properties_yaf_material.py