### PR TITLE
Sigma texture mapping for Shiny Diffuse material

### DIFF
--- a/io/yaf_material.py
+++ b/io/yaf_material.py
@@ -364,6 +364,7 @@ class yafMaterial:
         translRoot = ''
         mirrorRoot = ''
         bumpRoot = ''
+        sigmaOrenRoot = ''
 
         for mtex in used_textures:
             if not mtex.texture:
@@ -401,6 +402,11 @@ class yafMaterial:
                 used = True
                 bumpRoot = lname
 
+            lname = "sigma_oren_layer%x" % i
+            if self.writeTexLayer(lname, mappername, sigmaOrenRoot, mtex, mtex.use_map_hardness, [0], mtex.hardness_factor):
+                used = True
+                sigmaOrenRoot = lname
+
             if used:
                 self.writeMappingNode(mappername, mtex.texture.name, mtex)
             i += 1
@@ -418,6 +424,8 @@ class yafMaterial:
             yi.paramsSetString("mirror_shader", mirrorRoot)
         if len(bumpRoot) > 0:
             yi.paramsSetString("bump_shader", bumpRoot)
+        if len(sigmaOrenRoot) > 0:
+            yi.paramsSetString("sigma_oren_shader", sigmaOrenRoot)        
 
         yi.paramsSetColor("color", bCol[0], bCol[1], bCol[2])
         yi.paramsSetFloat("transparency", bTransp)

--- a/ui/properties_yaf_texture.py
+++ b/ui/properties_yaf_texture.py
@@ -569,6 +569,7 @@ class YAF_TEXTURE_PT_influence(YAF_TextureSlotPanel, Panel):
         shaderNodes = dict()
         shaderNodes["Bump"] = ["use_map_normal", "normal_factor", "Bump"]
         shaderNodes["MirrorAmount"] = ["use_map_raymir", "raymir_factor", "Mirror Amount"]
+        shaderNodes["SigmaOren"] = ["use_map_hardness", "hardness_factor", "Sigma Amount for Oren Nayar"]
         shaderNodes["MirrorColor"] = ["use_map_mirror", "mirror_factor", "Mirror Color"]
         shaderNodes["DiffuseColor"] = ["use_map_color_diffuse", "diffuse_color_factor", "Diffuse Color"]
         shaderNodes["GlossyColor"] = ["use_map_color_spec", "specular_color_factor", "Glossy Color"]
@@ -582,7 +583,7 @@ class YAF_TEXTURE_PT_influence(YAF_TextureSlotPanel, Panel):
         materialShaderNodes["rough_glass"] = ["Bump", "MirrorColor"]
         materialShaderNodes["glossy"] = ["DiffuseColor", "GlossyColor", "GlossyAmount", "Bump"]
         materialShaderNodes["coated_glossy"] = ["DiffuseColor", "GlossyColor", "GlossyAmount", "Bump"]
-        materialShaderNodes["shinydiffusemat"] = ["DiffuseColor", "MirrorAmount", "MirrorColor", "Transparency", "Translucency", "Bump"]
+        materialShaderNodes["shinydiffusemat"] = ["DiffuseColor", "MirrorAmount", "MirrorColor", "Transparency", "Translucency", "Bump", "SigmaOren"]
         materialShaderNodes["blend"] = ["BlendAmount"]
 
         if isinstance(idblock, Material):


### PR DESCRIPTION
Changes to add texture mapping to the Sigma parameter of the Shiny Diffuse - Oren Nayar material, to create more realistic diffuse materials. Changes are needed both in Core and the Blender-Exporter.

 Changes to be committed:
	modified:   io/yaf_material.py
	modified:   ui/properties_yaf_texture.py