### PR TITLE
New Color Pipeline workflow and corrections to Alpha Premultiply

### DIFF
--- a/io/yaf_export.py
+++ b/io/yaf_export.py
@@ -318,7 +318,7 @@ class YafaRayRenderEngine(bpy.types.RenderEngine):
                 input_color_values_color_space = "XYZ"
                 
             elif scene.display_settings.display_device == "None":
-                input_color_values_color_space = "Raw_manual_Gamma"
+                input_color_values_color_space = "Raw_Manual_Gamma"
                 input_color_values_gamma = scene.gs_gamma  #We only use the selected gamma if the output device is set to "None"
             
             self.yi.setInputColorSpace("LinearRGB", 1.0)    #Values from Blender, color picker floating point data are already linear (linearized by Blender)

--- a/io/yaf_export.py
+++ b/io/yaf_export.py
@@ -294,7 +294,7 @@ class YafaRayRenderEngine(bpy.types.RenderEngine):
 
         if scene.gs_type_render == "file":
             self.setInterface(yafrayinterface.yafrayInterface_t())
-            self.yi.setInputGamma(scene.gs_gamma_input, True)
+            self.yi.setInputColorSpace("LinearRGB", 1.0)    #When rendering into Blender, color picker floating point data is already linear (linearized by Blender)
             self.outputFile, self.output, self.file_type = self.decideOutputFileName(fp, scene.img_output)
             self.yi.paramsClearAll()
             self.yi.paramsSetString("type", self.file_type)
@@ -307,7 +307,23 @@ class YafaRayRenderEngine(bpy.types.RenderEngine):
 
         elif scene.gs_type_render == "xml":
             self.setInterface(yafrayinterface.xmlInterface_t())
-            self.yi.setInputGamma(scene.gs_gamma_input, True)
+            
+            input_color_values_color_space = "sRGB"
+            input_color_values_gamma = 1.0
+
+            if scene.display_settings.display_device == "sRGB":
+                input_color_values_color_space = "sRGB"
+                
+            elif scene.display_settings.display_device == "XYZ":
+                input_color_values_color_space = "XYZ"
+                
+            elif scene.display_settings.display_device == "None":
+                input_color_values_color_space = "Raw_manual_Gamma"
+                input_color_values_gamma = scene.gs_gamma  #We only use the selected gamma if the output device is set to "None"
+            
+            self.yi.setInputColorSpace("LinearRGB", 1.0)    #Values from Blender, color picker floating point data are already linear (linearized by Blender)
+            self.yi.setXMLColorSpace(input_color_values_color_space, input_color_values_gamma)  #To set the XML interface to write the XML values with the correction included for the selected color space (and gamma if applicable)
+            
             self.outputFile, self.output, self.file_type = self.decideOutputFileName(fp, 'XML')
             self.yi.paramsClearAll()
             self.co = yafrayinterface.imageOutput_t()
@@ -315,7 +331,7 @@ class YafaRayRenderEngine(bpy.types.RenderEngine):
 
         else:
             self.setInterface(yafrayinterface.yafrayInterface_t())
-            self.yi.setInputGamma(scene.gs_gamma_input, True)
+            self.yi.setInputColorSpace("LinearRGB", 1.0)    #When rendering into Blender, color picker floating point data is already linear (linearized by Blender)
 
         self.yi.startScene()
         self.exportScene()
@@ -334,7 +350,7 @@ class YafaRayRenderEngine(bpy.types.RenderEngine):
             self.update_stats("YafaRay Rendering:", "Rendering to {0}".format(self.outputFile))
             self.yi.render(self.co)
             result = self.begin_result(0, 0, self.resX, self.resY)
-            lay = result.layers[0] if bpy.app.version < (2, 74, 4 ) else result.layers[0].passes[0]
+            lay = result.layers[0] #if bpy.app.version < (2, 74, 4 ) else result.layers[0].passes[0] #FIXME?
 
             # exr format has z-buffer included, so no need to load '_zbuffer' - file
             if scene.gs_z_channel and not scene.img_output == 'OPEN_EXR':

--- a/io/yaf_scene.py
+++ b/io/yaf_scene.py
@@ -139,7 +139,11 @@ def exportRenderSettings(yi, scene):
 
     yi.paramsSetBool("clamp_rgb", scene.gs_clamp_rgb)
     yi.paramsSetBool("show_sam_pix", scene.gs_show_sam_pix)
-    yi.paramsSetBool("premult", scene.gs_premult)
+
+    if scene.gs_type_render == "file" or scene.gs_type_render == "xml":
+        yi.paramsSetBool("premult", scene.gs_premult)
+    else:
+        yi.paramsSetBool("premult", True)   #We force alpha premultiply when rendering into Blender as it expects premultiplied input
 
     yi.paramsSetInt("tile_size", scene.gs_tile_size)
     yi.paramsSetString("tiles_order", scene.gs_tile_order)

--- a/io/yaf_scene.py
+++ b/io/yaf_scene.py
@@ -108,7 +108,7 @@ def exportRenderSettings(yi, scene):
             output_device_color_space = "XYZ"
             
         elif scene.display_settings.display_device == "None":
-            output_device_color_space = "Raw_manual_Gamma"
+            output_device_color_space = "Raw_Manual_Gamma"
             output_device_gamma = scene.gs_gamma  #We only use the selected gamma if the output device is set to "None"
 
     else:   #Render into Blender
@@ -118,7 +118,7 @@ def exportRenderSettings(yi, scene):
             output_device_color_space = "LinearRGB"  #If we render into Blender, YafaRay generates linear output and Blender does the conversion to the color space
            
         elif scene.display_settings.display_device == "None":
-            output_device_color_space = "Raw_manual_Gamma"
+            output_device_color_space = "Raw_Manual_Gamma"
             output_device_gamma = scene.gs_gamma  #We only use the selected gamma if the output device is set to "None"
         
     yi.paramsSetString("color_space", output_device_color_space)

--- a/io/yaf_scene.py
+++ b/io/yaf_scene.py
@@ -92,7 +92,37 @@ def exportRenderSettings(yi, scene):
     yi.paramsSetString("integrator_name", "default")
     yi.paramsSetString("volintegrator_name", "volintegr")
 
-    yi.paramsSetFloat("gamma", scene.gs_gamma)
+    output_device_color_space = "LinearRGB"
+    output_device_gamma = 1.0
+
+    if scene.gs_type_render == "file" or scene.gs_type_render == "xml":
+        output_device_color_space = "sRGB"
+
+        if scene.img_output == "OPEN_EXR" or scene.img_output == "HDR":  #If the output file is a HDR/EXR file, we force the render output to Linear
+            output_device_color_space = "LinearRGB"
+            
+        elif scene.display_settings.display_device == "sRGB":
+            output_device_color_space = "sRGB"
+            
+        elif scene.display_settings.display_device == "XYZ":
+            output_device_color_space = "XYZ"
+            
+        elif scene.display_settings.display_device == "None":
+            output_device_color_space = "Raw_manual_Gamma"
+            output_device_gamma = scene.gs_gamma  #We only use the selected gamma if the output device is set to "None"
+
+    else:   #Render into Blender
+        output_device_color_space = "LinearRGB"    #Blender expects a linear output from YafaRay
+
+        if scene.display_settings.display_device == "sRGB" or scene.display_settings.display_device == "XYZ" or scene.display_settings.display_device == "Rec709":
+            output_device_color_space = "LinearRGB"  #If we render into Blender, YafaRay generates linear output and Blender does the conversion to the color space
+           
+        elif scene.display_settings.display_device == "None":
+            output_device_color_space = "Raw_manual_Gamma"
+            output_device_gamma = scene.gs_gamma  #We only use the selected gamma if the output device is set to "None"
+        
+    yi.paramsSetString("color_space", output_device_color_space)
+    yi.paramsSetFloat("gamma", output_device_gamma)
 
     exportAA(yi, scene)
 

--- a/io/yaf_texture.py
+++ b/io/yaf_texture.py
@@ -306,15 +306,34 @@ class yafTexture:
             image_tex = os.path.realpath(image_tex)
             image_tex = os.path.normpath(image_tex)
 
-            yi.printInfo("Exporter: Creating Texture: '{0}' type {1}: {2}".format(name, tex.yaf_tex_type, image_tex))
-
             yi.paramsSetString("type", "image")
             yi.paramsSetString("filename", image_tex)
 
             yi.paramsSetBool("use_alpha", tex.yaf_use_alpha)
             yi.paramsSetBool("calc_alpha", tex.use_calculate_alpha)
             yi.paramsSetBool("normalmap", tex.yaf_is_normal_map)
-            yi.paramsSetFloat("gamma", scene.gs_gamma_input)
+            yi.paramsSetString("fileformat", fileformat.upper())
+            
+            texture_color_space = "sRGB"
+            texture_gamma = 1.0
+
+            if tex.image.colorspace_settings.name == "sRGB" or tex.image.colorspace_settings.name == "VD16":
+                texture_color_space = "sRGB"
+                
+            elif tex.image.colorspace_settings.name == "XYZ":
+                texture_color_space = "XYZ"
+                
+            elif tex.image.colorspace_settings.name == "Linear" or tex.image.colorspace_settings.name == "Linear ACES" or tex.image.colorspace_settings.name == "Non-Color":
+                texture_color_space = "LinearRGB"
+                
+            elif tex.image.colorspace_settings.name == "Raw":
+                texture_color_space = "Raw_manual_Gamma"
+                texture_gamma = tex.yaf_gamma_input  #We only use the selected gamma if the color space is set to "Raw"
+                
+            yi.paramsSetString("color_space", texture_color_space)
+            yi.paramsSetFloat("gamma", texture_gamma)
+
+            yi.printInfo("Exporter: Creating Texture: '{0}' type {1}: {2}. Texture Color Space: '{3}', gamma={4}".format(name, tex.yaf_tex_type, image_tex, texture_color_space, texture_gamma))
 
             # repeat
             repeat_x = 1

--- a/io/yaf_texture.py
+++ b/io/yaf_texture.py
@@ -327,7 +327,7 @@ class yafTexture:
                 texture_color_space = "LinearRGB"
                 
             elif tex.image.colorspace_settings.name == "Raw":
-                texture_color_space = "Raw_manual_Gamma"
+                texture_color_space = "Raw_Manual_Gamma"
                 texture_gamma = tex.yaf_gamma_input  #We only use the selected gamma if the color space is set to "Raw"
                 
             yi.paramsSetString("color_space", texture_color_space)

--- a/io/yaf_world.py
+++ b/io/yaf_world.py
@@ -76,6 +76,25 @@ class yafWorld:
                         interpolate = 'bilinear'
                     #
                     yi.paramsSetString("interpolate", interpolate)
+
+                    texture_color_space = "sRGB"
+                    texture_gamma = 1.0
+
+                    if worldTex.image.colorspace_settings.name == "sRGB" or worldTex.image.colorspace_settings.name == "VD16":
+                        texture_color_space = "sRGB"
+                        
+                    elif worldTex.image.colorspace_settings.name == "XYZ":
+                        texture_color_space = "XYZ"
+                        
+                    elif worldTex.image.colorspace_settings.name == "Linear" or worldTex.image.colorspace_settings.name == "Linear ACES" or worldTex.image.colorspace_settings.name == "Non-Color":
+                        texture_color_space = "LinearRGB"
+                        
+                    elif worldTex.image.colorspace_settings.name == "Raw":
+                        texture_color_space = "Raw_manualGamma"
+                        texture_gamma = worldTex.yaf_gamma_input  #We only use the selected gamma if the color space is set to "Raw"
+                
+                    yi.paramsSetString("color_space", texture_color_space)
+                    yi.paramsSetFloat("gamma", texture_gamma)
                     
                     yi.createTexture("world_texture")
 

--- a/prop/yaf_texture.py
+++ b/prop/yaf_texture.py
@@ -20,7 +20,8 @@
 
 import bpy
 from bpy.props import (EnumProperty,
-                       BoolProperty)
+                       BoolProperty,
+                       FloatProperty)
 
 Texture = bpy.types.Texture
 
@@ -61,9 +62,15 @@ def register():
         name="Use alpha image info",
         description="Use alpha values for image mapping",
         default=False)
+        
+    Texture.yaf_gamma_input = FloatProperty(
+        name="Gamma input",
+        description="Gamma correction applied to input texture",
+        min=0, max=5, default=1.0)
 
 
 def unregister():
     Texture.yaf_tex_type
     Texture.yaf_is_normal_map
     Texture.yaf_use_alpha
+    Texture.yaf_gamma_input

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -26,6 +26,7 @@ from . import properties_yaf_world
 from . import properties_yaf_strand
 from . import properties_yaf_object
 from . import properties_yaf_light
+from . import properties_yaf_scene
 
 from bl_ui import properties_object as properties_object
 for member in dir(properties_object):  # add all "object" panels from blender
@@ -63,12 +64,16 @@ for member in dir(properties_data_speaker):  # add all "speaker (SOC 2011, peppe
         pass
 del properties_data_speaker
 
-# YafaRay did not display the Scene panels anymore, due to addition of COMPAT_ENGINES to them
 from bl_ui import properties_scene as properties_scene
 for member in dir(properties_scene):
-    subclass = getattr(properties_scene, member)
-    try:
-        subclass.COMPAT_ENGINES.add('YAFA_RENDER')
-    except:
-        pass
+
+    if member != "SCENE_PT_color_management":   #YafaRay Color management panel is customized in properties_yaf_scene.
+        #FIXME: The customized YafaRay panel appears at the end of the Blender scene tab panels, I don't know how to rearrange the panels to keep YafaRay color management in the same place as Blender Color Management panel was.
+
+            subclass = getattr(properties_scene, member)
+            try:
+                subclass.COMPAT_ENGINES.add('YAFA_RENDER')
+            except:
+                pass
+
 del properties_scene

--- a/ui/properties_yaf_general_settings.py
+++ b/ui/properties_yaf_general_settings.py
@@ -51,7 +51,6 @@ class YAF_PT_general_settings(RenderButtonsPanel, Panel):
         split = layout.split(percentage=0.58)
         col = split.column()
         col.prop(scene, "gs_ray_depth")
-        col.prop(scene, "gs_gamma")
         col.prop(scene, "gs_type_render")
         sub = col.column()
         sub.enabled = scene.gs_type_render == "into_blender"
@@ -61,7 +60,7 @@ class YAF_PT_general_settings(RenderButtonsPanel, Panel):
         sub = col.column()
         sub.enabled = scene.gs_transp_shad
         sub.prop(scene, "gs_shadow_depth")
-        col.prop(scene, "gs_gamma_input")
+        #col.prop(scene, "gs_gamma_input")      #No longer needed
         sub = col.column()
         sub.enabled = scene.gs_auto_threads == False
         sub.prop(scene, "gs_threads")

--- a/ui/properties_yaf_render.py
+++ b/ui/properties_yaf_render.py
@@ -158,6 +158,17 @@ class YAFRENDER_PT_output(RenderButtonsPanel, Panel):
                 else:
                     row = layout.row(align=True)
                     row.label(text="YafaRay doesn't support '" + sc.display_settings.display_device + "', assuming sRGB", icon="ERROR")
+                    
+        if sc.gs_type_render == "file" or sc.gs_type_render == "xml":
+                split = layout.split(percentage=0.6)
+                col = split.column()
+                col.prop(sc, "gs_premult", text = "Premultiply Alpha")
+                if sc.img_output  == "OPEN_EXR" and not sc.gs_premult:
+                    row = layout.row(align=True)
+                    row.label(text="Typically you should enable Premultiply in EXR files", icon="INFO")
+                if sc.img_output  == "PNG" and sc.gs_premult:
+                    row = layout.row(align=True)
+                    row.label(text="Typically you should disable Premultiply in PNG files", icon="INFO")
 
 
 class YAFRENDER_PT_post_processing(RenderButtonsPanel, Panel):

--- a/ui/properties_yaf_render.py
+++ b/ui/properties_yaf_render.py
@@ -146,7 +146,7 @@ class YAFRENDER_PT_output(RenderButtonsPanel, Panel):
                 
                 if sc.display_settings.display_device == "None":
                     col = split.column()
-                    col.prop(scene, "gs_gamma", text = "Gamma")
+                    col.prop(sc, "gs_gamma", text = "Gamma")
 
                 if sc.display_settings.display_device == "sRGB":
                     pass

--- a/ui/properties_yaf_render.py
+++ b/ui/properties_yaf_render.py
@@ -137,6 +137,28 @@ class YAFRENDER_PT_output(RenderButtonsPanel, Panel):
         col = split.column()
         col.row().prop(image_settings, "color_mode", text="Color", expand=True)
 
+        if sc.img_output == "OPEN_EXR" or sc.img_output == "HDR":  #If the output file is a HDR/EXR file, we force the render output to Linear
+                pass
+        elif sc.gs_type_render == "file" or sc.gs_type_render == "xml":
+                split = layout.split(percentage=0.6)
+                col = split.column()
+                col.prop(sc.display_settings, "display_device")
+                
+                if sc.display_settings.display_device == "None":
+                    col = split.column()
+                    col.prop(scene, "gs_gamma", text = "Gamma")
+
+                if sc.display_settings.display_device == "sRGB":
+                    pass
+                elif sc.display_settings.display_device == "None":
+                    pass
+                elif sc.display_settings.display_device == "XYZ":
+                    row = layout.row(align=True)
+                    row.label(text="YafaRay 'XYZ' support is experimental and may not give the expected results", icon="ERROR")
+                else:
+                    row = layout.row(align=True)
+                    row.label(text="YafaRay doesn't support '" + sc.display_settings.display_device + "', assuming sRGB", icon="ERROR")
+
 
 class YAFRENDER_PT_post_processing(RenderButtonsPanel, Panel):
     bl_label = "Post Processing"

--- a/ui/properties_yaf_scene.py
+++ b/ui/properties_yaf_scene.py
@@ -1,0 +1,59 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+# <pep8 compliant>
+
+import bpy
+from yafaray.ot import yafaray_presets
+from bl_ui.properties_scene import SceneButtonsPanel
+from bpy.types import Panel, Menu
+
+class YAF_PT_color_management(SceneButtonsPanel, Panel):
+    bl_label = "Color Management"
+    COMPAT_ENGINES = {'YAFA_RENDER'}
+
+    def draw(self, context):
+        layout = self.layout
+
+        scene = context.scene
+
+        col = layout.column()
+        col.label(text="Display:")
+        col.prop(scene.display_settings, "display_device")
+
+        if scene.display_settings.display_device == "sRGB":
+            pass
+        elif scene.display_settings.display_device == "None":
+            row = layout.row(align=True)
+            row.prop(scene, "gs_gamma", text = "Display device output gamma")
+        elif scene.display_settings.display_device == "XYZ":
+            row = layout.row(align=True)
+            row.label(text="YafaRay 'XYZ' support is experimental and may not give the expected results", icon="ERROR")
+        else:
+            row = layout.row(align=True)
+            row.label(text="YafaRay doesn't support '" + scene.display_settings.display_device + "', assuming sRGB", icon="ERROR")
+
+        col = layout.column()
+        col.separator()
+        col.label(text="Render:")
+        col.template_colormanaged_view_settings(scene, "view_settings")
+
+
+if __name__ == "__main__":  # only for live edit.
+    import bpy
+    bpy.utils.register_module(__name__)

--- a/ui/properties_yaf_texture.py
+++ b/ui/properties_yaf_texture.py
@@ -259,6 +259,28 @@ class YAF_TEXTURE_PT_image(YAF_TextureTypePanel, Panel):
         tex = context.texture
         layout.template_image(tex, "image", tex.image_user)
 
+        if tex.image.colorspace_settings.name == "sRGB" or tex.image.colorspace_settings.name == "Linear" or tex.image.colorspace_settings.name == "Non-Color":
+            pass
+        
+        elif tex.image.colorspace_settings.name == "XYZ":
+            row = layout.row(align=True)
+            row.label(text="YafaRay 'XYZ' support is experimental and may not give the expected results", icon="ERROR")
+        
+        elif tex.image.colorspace_settings.name == "Linear ACES":
+            row = layout.row(align=True)
+            row.label(text="YafaRay doesn't support '" + tex.image.colorspace_settings.name + "', assuming linear RGB", icon="ERROR")
+        
+        elif tex.image.colorspace_settings.name == "Raw":
+            row = layout.row(align=True)
+            row.prop(tex, "yaf_gamma_input", text="Texture gamma input correction")
+
+        else:
+            row = layout.row(align=True)
+            row.label(text="YafaRay doesn't support '" + tex.image.colorspace_settings.name + "', assuming sRGB", icon="ERROR")
+            
+        row = layout.row(align=True)
+        row.label(text="Note: for bump/normal maps, textures are always considered Linear", icon="INFO")
+        
 
 class YAF_TEXTURE_PT_image_sampling(YAF_TextureTypePanel, Panel):
     bl_label = "Image Sampling"

--- a/ui/properties_yaf_world.py
+++ b/ui/properties_yaf_world.py
@@ -78,6 +78,26 @@ class YAFWORLD_PT_world(WorldButtonsPanel, Panel):
                 if  tex.yaf_tex_type == "IMAGE":  # it allows to change the used image
                     #
                     layout.template_image(tex, "image", tex.image_user, compact=True)
+                    
+                    if tex.image.colorspace_settings.name == "sRGB" or tex.image.colorspace_settings.name == "Linear" or tex.image.colorspace_settings.name == "Non-Color":
+                        pass
+                    
+                    elif tex.image.colorspace_settings.name == "XYZ":
+                        row = layout.row(align=True)
+                        row.label(text="YafaRay 'XYZ' support is experimental and may not give the expected results", icon="ERROR")
+                    
+                    elif tex.image.colorspace_settings.name == "Linear ACES":
+                        row = layout.row(align=True)
+                        row.label(text="YafaRay doesn't support '" + tex.image.colorspace_settings.name + "', assuming linear RGB", icon="ERROR")
+                    
+                    elif tex.image.colorspace_settings.name == "Raw":
+                        row = layout.row(align=True)
+                        row.prop(tex, "yaf_gamma_input", text="Texture gamma input correction")
+
+                    else:
+                        row = layout.row(align=True)
+                        row.label(text="YafaRay doesn't support '" + tex.image.colorspace_settings.name + "', assuming sRGB", icon="ERROR")
+                    
                     #
                 else:
                     # TODO: create message about not allow texture type


### PR DESCRIPTION
Initial changes to try to fix the (apparently broken) YafaRay color pipeline workflow and to replace the simple gamma input/output correction with a proper sRGB decoding/coding in non-HDR files.

Also some changes to Alpha Premultiply option, that was orphaned in the Exporter a long time ago.

More information here: 
http://www.yafaray.org/node/670
http://yafaray.org/node/682

* Improved Blender Color Space integration.
* The "simple" gamma correction has been replaced by Color Spaces:
	- LinearRGB			Linear values, no gamma correction
	- sRGB				sRGB encoding/decoding
	- XYZ				XYZ (very experimental) support
	- Raw_Manual_Gamma	Raw linear values that allow to set a simple gamma output correction manually

* Fixed: Double application of input gamma to the Blender Color picker. So now scenes will look brighter in general, but they should also look more realistic with less tweaking.
* Gamma input correction no longer used. The color picker floating point color values will be considered already linear and no conversion applied to them.
* For textures, added specific per-texture Color Space and gamma parameters.
* The color values exported to the XML file will be encoded acording to Blender Output Device Color Space setting.
* In yafaray-xml, new commandline option added: "-ics" or "--input-color-space" that allows to select how to interpret the XML color values. By default, for backwards compatibility, color values will be read as "LinearRGB", but using "-ics sRGB", the color values will be interpreted as sRGB. This setting does *not* affect the textures, as they have already per-texture specific color space/gamma parameters.
* Fixed: when exporting to file there was an error in Blender while reopening it to be shown in the Blender image view.

* Blender expects an already premultiplied output from YafaRay, but if premultiply was disabled in an older version of YafaRay, it's no longer possible to enable it in recent versions of the Exporter, causing wrong renders into Blender.
* Now, premultiply is always forced to "True" when exporting into Blender
* Also, when exporting into File or XML, a checkbox next to the output file name is shown to allow enabling or disabling Premultiply Alpha, giving more choices to the users depending whether they want their output images to be premultiplied or not
