### PR TITLE
Automatic AA Threshold reduction based on a "floor" for resampled pixels

### DIFF
--- a/io/yaf_scene.py
+++ b/io/yaf_scene.py
@@ -79,6 +79,7 @@ def exportAA(yi, scene):
     yi.paramsSetFloat("AA_pixelwidth", scene.AA_pixelwidth)
     yi.paramsSetFloat("AA_threshold", scene.AA_threshold)
     yi.paramsSetString("filter_type", scene.AA_filter_type)
+    yi.paramsSetInt("AA_resampled_floor", scene.AA_resampled_floor)
 
 
 def exportRenderSettings(yi, scene):

--- a/prop/yaf_scene.py
+++ b/prop/yaf_scene.py
@@ -381,6 +381,13 @@ def register():
         min=0.0, max=1.0, precision=4,
         default=0.05)
 
+    Scene.AA_resampled_floor = IntProperty(
+        name="Resampled floor",
+        description=("For better noise reduction, if the amount of resampled pixels go below this value,"
+                     " the AA threshold will automatically decrease before the next pass"),
+        min=0,
+        default=0)
+
     Scene.AA_pixelwidth = FloatProperty(
         name="Pixelwidth",
         description="AA filter size",
@@ -458,3 +465,4 @@ def unregister():
     Scene.AA_threshold
     Scene.AA_pixelwidth
     Scene.AA_filter_type
+    Scene.AA_resampled_floor

--- a/ui/properties_yaf_AA_settings.py
+++ b/ui/properties_yaf_AA_settings.py
@@ -50,6 +50,8 @@ class YAF_PT_AA_settings(RenderButtonsPanel, Panel):
         spp.prop(scene, "AA_passes")
         sub.prop(scene, "AA_inc_samples")
         sub.prop(scene, "AA_threshold")
+        if scene.intg_light_method != "SPPM":
+            sub.prop(scene, "AA_resampled_floor")
 
 
 if __name__ == "__main__":  # only for live edit.


### PR DESCRIPTION
For better noise reduction, as requested in the bugtracker http://yafaray.org/node/690 I've added the functionality of automatically decreasing the AA Threshold before the next pass if the amount of resampled pixels is below a certain "floor" value selectable by the user.

This first version of the feature will have a hardcoded value of 0.9f for AA thresold reduction. This means that, every time a pass resamples fewer pixels than the "floor" selected by the user, the AA Threshold will be decreased by 10% before the next pass.

 Changes to be committed:
	modified:   io/yaf_scene.py
	modified:   prop/yaf_scene.py
	modified:   ui/properties_yaf_AA_settings.py