### PR TITLE
New texture interpolation parameter

### DIFF
--- a/io/yaf_texture.py
+++ b/io/yaf_texture.py
@@ -316,6 +316,8 @@ class yafTexture:
             yi.paramsSetBool("normalmap", tex.yaf_is_normal_map)
             yi.paramsSetFloat("gamma", scene.gs_gamma_input)
 
+            yi.paramsSetString("interpolate", tex.yaf_tex_interpolate)
+
             # repeat
             repeat_x = 1
             repeat_y = 1

--- a/prop/yaf_texture.py
+++ b/prop/yaf_texture.py
@@ -62,8 +62,18 @@ def register():
         description="Use alpha values for image mapping",
         default=False)
 
+    Texture.yaf_tex_interpolate = EnumProperty(
+        name="Interpolation",
+        items=(
+            ('bilinear', "Bilinear (default)", ""),
+            ('bicubic', "Bicubic", ""),
+            ('none', "No interpolation", "")
+        ),
+        default='bilinear')
+
 
 def unregister():
     Texture.yaf_tex_type
     Texture.yaf_is_normal_map
     Texture.yaf_use_alpha
+    Texture.yaf_tex_interpolate

--- a/ui/properties_yaf_texture.py
+++ b/ui/properties_yaf_texture.py
@@ -280,6 +280,8 @@ class YAF_TEXTURE_PT_image_sampling(YAF_TextureTypePanel, Panel):
             row.prop(tex, "yaf_use_alpha", text="Use Alpha")
             row.prop(tex, "use_calculate_alpha", text="Calculate Alpha")
             layout.prop(tex, "use_flip_axis", text="Flip X/Y Axis")
+            layout.prop(tex, "yaf_tex_interpolate")
+            
         else:
             row.prop(tex, "use_interpolation", text="Use image background interpolation")
             #row.prop(tex, "use_calculate_alpha", text="Calculate Alpha")


### PR DESCRIPTION
As requested in the forum http://www.yafaray.org/community/forum/viewtopic.php?f=22&p=31289#p31289

It's not currently possible in the exporter to select the image texture interpolation type, but in the Core code we can actually select "none", "bilinear" (default) or "bicubic". So, I've added this parameter to the Exporter as well, in the Image Sampling section.
	modified:   io/yaf_texture.py
	modified:   prop/yaf_texture.py
	modified:   ui/properties_yaf_texture.py