### PR TITLE
Add error message if exception during tile rendering

### DIFF
--- a/io/yaf_export.py
+++ b/io/yaf_export.py
@@ -24,6 +24,7 @@ import os
 import threading
 import time
 import yafrayinterface
+import traceback
 from yafaray import PLUGIN_PATH
 from yafaray import YAF_ID_NAME
 from .yaf_object import yafObject
@@ -368,11 +369,17 @@ class YafaRayRenderEngine(bpy.types.RenderEngine):
                     if bpy.app.version < (2, 74, 4 ):
                         l.rect, l.passes[0].rect = tile
                     else:
-                        l.passes[0].rect, l.passes[1].rect = tile
-                except:
-                    pass
+                        if self.is_preview:
+                            l.passes[0].rect = tile[0]
+                        else:
+                            l.passes[0].rect, l.passes[1].rect = tile
+                    
+                    self.end_result(res)
 
-                self.end_result(res)
+                except:
+                    print("Exporter: Exception while rendering in drawAreaCallback function:")
+                    traceback.print_exc()
+
 
             def flushCallback(*args):
                 w, h, tile = args
@@ -382,11 +389,16 @@ class YafaRayRenderEngine(bpy.types.RenderEngine):
                     if bpy.app.version < (2, 74, 4 ):
                         l.rect, l.passes[0].rect = tile
                     else:
-                        l.passes[0].rect, l.passes[1].rect = tile
-                except BaseException as e:
-                    pass
+                        if self.is_preview:
+                            l.passes[0].rect = tile[0]
+                        else:
+                            l.passes[0].rect, l.passes[1].rect = tile
 
-                self.end_result(res)
+                    self.end_result(res)
+
+                except BaseException as e:
+                    print("Exporter: Exception while rendering in flushCallback function:")
+                    traceback.print_exc()
 
             t = threading.Thread(
                                     target=self.yi.render,


### PR DESCRIPTION
Until now, if for some reason there was a problem with the tile rendering in the exporter, due to errors in the exporter code or (more likely) unexpected changes in the Blender Rendering API, there were no error messages at all, but the render was totally black, making troubleshooting much more difficult for users and developers.

I've added code that shows an error message if there is an exception while rendering the tiles and the cause of the exception. I hope that with this we will be able to better react to changes in Blender API, etc, that affect the Rendering interface.

While implementing this, I discovered there were exceptions in the Material Preview (didn't seem to affect the preview itself, though), so I've used the oportunity to fix that as well.

Changes to be committed:
modified: io/yaf_export.py